### PR TITLE
Add self var to AuthUser function

### DIFF
--- a/yubikey-otp/openvpn_otp_auth.py
+++ b/yubikey-otp/openvpn_otp_auth.py
@@ -33,7 +33,7 @@ class OpenVPNOTPAuth:
 		self.clientID = clientID
 		self.secretKey = secretKey
 
-	def AuthUser(username, password):
+	def AuthUser(self, username, password):
 		# Extract the token from the encoded password
 		if password.startswith('SCRV1:'):
 			# Extract the actual password and token


### PR DESCRIPTION
Resolves the following error... 
```
Traceback (most recent call last):
  File "openvpn_otp_auth.py", line 108, in <module>
    if authClient.AuthUser(username, password):
TypeError: AuthUser() takes exactly 2 arguments (3 given)
```