### PR TITLE
Bugfix: Close reading end of pipe when completed to avoid file descriptor leak

### DIFF
--- a/yubikey-u2f-pam-plugin/auth-pam-u2f.c
+++ b/yubikey-u2f-pam-plugin/auth-pam-u2f.c
@@ -934,6 +934,7 @@ u2f_auth_verify(char *username, char* password, char* script_path, char **client
         buffer[br - 1] = '\0';
     }
     wait( &status);
+    close(pipefd[0]);
 
     if (WIFEXITED(status)) {
         if (client_reason != NULL && WEXITSTATUS(status) == 2) {


### PR DESCRIPTION
When reading from the spawned Python script is completed, we need to close the reading end of the pipe to avoid a file descriptor leak.

We noticed on our VPN instances that after a certain amount of connections that the system would no longer be able to process new incoming connections.

While here, I have also updated some of the code around how the reason is returned so that we are not returning a pointer to a variable on the stack of the callee to the caller. While it may work for right now, it is rather unorthodox.