### PR TITLE
Bugfix: dlerror() implicit definition and returning pointer to stack variable to caller

### DIFF
--- a/yubikey-u2f-pam-plugin/auth-pam-u2f.c
+++ b/yubikey-u2f-pam-plugin/auth-pam-u2f.c
@@ -756,7 +756,7 @@ pam_server(int fd, const char *service, int verb, const struct name_value_list *
      */
     if (!dlopen_pam(pam_so))
     {
-        fprintf(stderr, "AUTH-PAM: BACKGROUND: could not load PAM lib %s: %d\n", pam_so, dlerror());
+        fprintf(stderr, "AUTH-PAM: BACKGROUND: could not load PAM lib %s: %s\n", pam_so, dlerror());
         send_control(fd, RESPONSE_INIT_FAILED);
         goto done;
     }

--- a/yubikey-u2f-pam-plugin/auth-pam-u2f.c
+++ b/yubikey-u2f-pam-plugin/auth-pam-u2f.c
@@ -50,6 +50,7 @@
 #include <fcntl.h>
 #include <signal.h>
 #include <syslog.h>
+#include <dlfcn.h>
 #include "utils.h"
 
 #include <openvpn-plugin.h>

--- a/yubikey-u2f-pam-plugin/auth-pam-u2f.c
+++ b/yubikey-u2f-pam-plugin/auth-pam-u2f.c
@@ -934,6 +934,7 @@ u2f_auth_verify(char *username, char* password, char* script_path, char **client
         buffer[br - 1] = '\0';
     }
     wait( &status);
+    close(pipefd[0]);
 
     if (WIFEXITED(status)) {
         if (client_reason != NULL && WEXITSTATUS(status) == 2) {


### PR DESCRIPTION
As requested in https://github.com/thesparklabs/openvpn-two-factor-extensions/pull/4 I have split this off, it is still based upon my previous changes for fixing file descriptor leak.